### PR TITLE
Add tranfer rollback validation & Manas ID creation improvements

### DIFF
--- a/economics/exceptions/__init__.py
+++ b/economics/exceptions/__init__.py
@@ -1,5 +1,7 @@
 from .insufficient_funds_for_system_withdrawal import *
 from .insufficient_funds_for_transfer import *
+from .insufficient_funds_for_transfer_rollback import *
 from .transaction_does_not_exist import *
 from .transaction_is_not_transfer import *
+from .transfer_rollback_time_expired import *
 from .transfer_sender_does_not_match import *

--- a/economics/exceptions/insufficient_funds_for_transfer_rollback.py
+++ b/economics/exceptions/insufficient_funds_for_transfer_rollback.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+__all__ = ('InsufficientFundsForTransferRollbackError',)
+
+
+@dataclass(frozen=True, slots=True)
+class InsufficientFundsForTransferRollbackError(Exception):
+    transaction_id: UUID

--- a/economics/exceptions/transfer_rollback_time_expired.py
+++ b/economics/exceptions/transfer_rollback_time_expired.py
@@ -1,0 +1,2 @@
+class TransferRollbackTimeExpiredError(Exception):
+    pass

--- a/economics/selectors.py
+++ b/economics/selectors.py
@@ -56,7 +56,11 @@ def get_transaction_by_id(transaction_id: UUID) -> Transaction:
                                       does not exist.
     """
     try:
-        return Transaction.objects.get(id=transaction_id)
+        return (
+            Transaction.objects
+            .select_related('sender')
+            .get(id=transaction_id)
+        )
     except Transaction.DoesNotExist:
         raise TransactionDoesNotExistError(
             f'Transaction with id {transaction_id} does not exist',

--- a/economics/services/transfers.py
+++ b/economics/services/transfers.py
@@ -106,6 +106,9 @@ def rollback_transfer(*, transaction: Transaction, user_id: int) -> None:
                                          match the user.
         TransferRollbackTimeExpiredError: If the transaction rollback time
                                           expired.
+        InsufficientFundsForTransferRollbackError: If the user has insufficient
+                                                  funds to rollback the
+                                                  transfer.
     """
     validate_transaction_is_transfer(transaction)
     validate_transfer_sender_matches_user(

--- a/economics/services/transfers.py
+++ b/economics/services/transfers.py
@@ -1,13 +1,17 @@
+from django.utils import timezone
+
 from economics.exceptions import (
     InsufficientFundsForTransferError,
     TransferSenderDoesNotMatchError,
     TransactionIsNotTransferError,
+    TransferRollbackTimeExpiredError,
+    InsufficientFundsForTransferRollbackError,
 )
 from economics.models import Transaction
 from economics.services.balance import compute_user_balance
 from users.models import User
 
-__all__ = ('create_transfer', 'delete_user_transaction')
+__all__ = ('create_transfer', 'rollback_transfer')
 
 
 def create_transfer(
@@ -51,29 +55,64 @@ def create_transfer(
     return transaction
 
 
-def delete_user_transaction(
+def validate_transaction_is_transfer(transaction: Transaction) -> None:
+    if not transaction.is_transfer:
+        raise TransactionIsNotTransferError(
+            transaction_id=transaction.id,
+        )
+
+
+def validate_transfer_sender_matches_user(
         *,
         transaction: Transaction,
         user_id: int,
 ) -> None:
+    if transaction.sender_id != user_id:
+        raise TransferSenderDoesNotMatchError(
+            transaction_id=transaction.id,
+            sender_id=user_id,
+        )
+
+
+def validate_transfer_rollback_time_expired(transaction: Transaction) -> None:
+    now = timezone.now()
+    is_transfer_rollback_time_expired = (
+            now - transaction.created_at > timezone.timedelta(minutes=10)
+    )
+    if is_transfer_rollback_time_expired:
+        raise TransferRollbackTimeExpiredError
+
+
+def validate_user_balance_for_transfer_rollback(
+        transaction: Transaction,
+) -> None:
+    user_balance = compute_user_balance(user=transaction.sender)
+    if user_balance < transaction.amount:
+        raise InsufficientFundsForTransferRollbackError(
+            transaction_id=transaction.id,
+        )
+
+
+def rollback_transfer(*, transaction: Transaction, user_id: int) -> None:
     """Delete a user's transaction.
 
     Keyword Args:
         transaction: Transaction to delete.
-        user_id: ID of the user who owns the transaction.
+        user_id: ID of the user who is deleting the transaction.
 
     Raises:
         TransactionIsNotTransferError: If the transaction is not a transfer.
         TransferSenderDoesNotMatchError: If the transaction's sender does not
                                          match the user.
+        TransferRollbackTimeExpiredError: If the transaction rollback time
+                                          expired.
     """
-    if not transaction.is_transfer:
-        raise TransactionIsNotTransferError(
-            transaction_id=transaction.id,
-        )
-    if transaction.sender_id != user_id:
-        raise TransferSenderDoesNotMatchError(
-            transaction_id=transaction.id,
-            sender_id=transaction.sender_id,
-        )
+    validate_transaction_is_transfer(transaction)
+    validate_transfer_sender_matches_user(
+        transaction=transaction,
+        user_id=user_id,
+    )
+    validate_transfer_rollback_time_expired(transaction)
+    validate_user_balance_for_transfer_rollback(transaction)
+
     transaction.delete()

--- a/economics/views/transfers/create_delete.py
+++ b/economics/views/transfers/create_delete.py
@@ -13,7 +13,7 @@ from economics.exceptions import (
     TransferSenderDoesNotMatchError,
 )
 from economics.selectors import get_transaction_by_id
-from economics.services import create_transfer, delete_user_transaction
+from economics.services import create_transfer, rollback_transfer
 from users.exceptions import UserDoesNotExistsError
 from users.selectors.users import get_user_by_id
 from users.serializers import UserPartialSerializer
@@ -93,7 +93,7 @@ class TransferCreateDeleteApi(APIView):
             raise NotFound(detail='Transaction does not exist')
 
         try:
-            delete_user_transaction(
+            rollback_transfer(
                 transaction=transaction,
                 user_id=user_id,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "duck-duck"
-version = "1.14.6"
+version = "1.14.7"
 description = ""
 authors = ["Eldos <eldos.baktybekov@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
- Now tranfer rollback will be validated by following criterias:
1. Transaction is a transfer, i.e. transaction has both sender and recipient.
2. Transfer's sender matches to user which is willing to rollback transaction.
3. Transfer rollback's time has not expired yet. It can be rolled back within 10 minutes right after creation.4. Recipient will have non-negative balance after rolling transfer back.

- Add helper-shortcut in Manas ID registration flow in admin panel so reward for registration will be automatically given to user.